### PR TITLE
RV Slide Group handling

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,6 +81,20 @@ Technical Achievements:
 - Thread-safe progress callbacks
 - Graceful failure handling per song
 
+### 🔧 Bug Fixes: RV Slide Group Handling
+**Status**: Complete  
+**Branch**: main (merged from bugfix/rv-slide-group-handling)  
+**Completed**: 2025-01-07  
+**PR**: #3
+
+Bug Fixes Implemented:
+- ✅ RV Slide Group naming with section numbers (verse 1 → Verse 1)
+- ✅ Configurable Swedish to English section mappings
+- ✅ Extra line feed removal from slide content
+- ✅ Created config/section_mappings.json for translation settings
+- ✅ Updated SectionDetector for number preservation
+- ✅ Fixed ProPresenter export content trimming
+
 ### 📋 Sprint 5: Advanced Features (Planned)
 **Status**: Not Started  
 
@@ -90,6 +104,23 @@ Planned Features:
 - Settings persistence
 - Bible verse detection
 - Duplicate file handling
+- **Settings GUI for Section Mappings** (Priority: High)
+
+#### Settings GUI Requirements
+**Section Mappings Editor**:
+- GUI interface to edit config/section_mappings.json
+- Add/Remove/Modify Swedish to English translations
+- Preview section mapping results
+- Validate mapping entries
+- Export/Import mapping configurations
+- Support for multiple languages (future: German, French, etc.)
+
+**Implementation Notes**:
+- Build on existing config/section_mappings.json structure
+- Provide real-time preview of mapping changes
+- Include validation for duplicate mappings
+- Allow users to reset to default mappings
+- Future extension: Support additional languages beyond Swedish
 
 ## Testing Approach
 

--- a/config/section_mappings.json
+++ b/config/section_mappings.json
@@ -1,0 +1,33 @@
+{
+  "section_mappings": {
+    "vers": "Verse",
+    "verse": "Verse",
+    "refräng": "Chorus",
+    "chorus": "Chorus",
+    "brygga": "Bridge", 
+    "bridge": "Bridge",
+    "förrefräng": "Pre-Chorus",
+    "pre-chorus": "Pre-Chorus",
+    "prechorus": "Pre-Chorus",
+    "intro": "Intro",
+    "outro": "Outro",
+    "slut": "Outro",
+    "tag": "Tag",
+    "ending": "Ending"
+  },
+  "number_mapping_rules": {
+    "preserve_numbers": true,
+    "start_from_one": true,
+    "format": "{section_name} {number}"
+  },
+  "gui_settings": {
+    "editable_via_gui": true,
+    "description": "Section name mappings from Swedish to English for ProPresenter export"
+  },
+  "notes": [
+    "This file maps Swedish section names to English equivalents",
+    "Numbers are preserved: 'vers 1' becomes 'Verse 1'",
+    "Case-insensitive matching is applied",
+    "These mappings will be editable from the GUI in future versions"
+  ]
+}


### PR DESCRIPTION
## Summary
This PR fixes critical bugs in RV Slide Group handling and removes extra line feeds from slide content in the ProPresenter export functionality.

## Issues Fixed

### 1. RV Slide Group Naming Issue
**Problem**: Section names like "verse 1" in RTF were being converted to generic "Verse" in XML RVSlideGrouping names, losing the numbering.

**Solution**:
- Created configurable Swedish to English section mappings (`config/section_mappings.json`)
- Updated `SectionDetector` to preserve section numbers: `verse 1` → `Verse 1`
- Fixed `ProPresenter6Exporter.format_section_name()` to preserve numbered sections
- Added support for GUI-editable settings for future enhancement

### 2. Extra Line Feed Issue
**Problem**: Every slide had an extra return/line feed after the last letter, creating unwanted blank lines.

**Solution**:
- Added proper content trimming in `create_text_element()`
- Removed unnecessary `\par` from RTF data generation
- Fixed PlainText, RTF, and WinFlow data to use trimmed content

## Changes Made

**New Files:**
- `config/section_mappings.json` - Configurable section name mappings

**Modified Files:**
- `src/processing/section_detector.py` - Configurable mappings and number preservation
- `src/export/propresenter.py` - Fixed section naming and content trimming

## Testing
Tested extensively with song ID 3347 (Hopp) from the test database:

**RV Slide Group Names (Before → After):**
- ✅ `verse 1` → `Verse 1` (was: generic `Verse`)
- ✅ `verse 2` → `Verse 2` (was: generic `Verse`) 
- ✅ `verse 3` → `Verse 3` (was: generic `Verse`)
- ✅ `chorus` → `Chorus` (unchanged, correct)

**Content Quality:**
- ✅ No extra line feeds at end of slide content
- ✅ PlainText content ends cleanly
- ✅ RTF data properly formatted without extra paragraph breaks

## Configuration
The new `config/section_mappings.json` file supports:
- Swedish to English mappings: `vers` → `Verse`, `refräng` → `Chorus`
- Number preservation rules
- Future GUI editing capabilities

🤖 Generated with [Claude Code](https://claude.ai/code)