### PR TITLE
Fix: Remove non-functional subfolder export option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the EasyWorship to ProPresenter Converter project will be documented in this file.
 
+## [1.1.5] - 2025-01-14
+
+### 🐛 Bug Fixes
+- **Remove Non-Functional Subfolder Export Option** (#13): Removed the broken subfolder export feature from Export Options dialog as it was not implemented in the export logic and added unnecessary complexity
+
+### 🔧 Technical Improvements
+- Simplified Export Options dialog by removing unused UI elements
+- Cleaned up configuration settings by removing subfolder-related options
+- Reduced code complexity and potential confusion for users
+
 ## [1.1.3] - 2025-01-13
 
 ### 🚀 Auto-Distribution System

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ Setup configuration for EasyWorship to ProPresenter Converter
 
 from setuptools import setup, find_packages
 
-VERSION = "1.1.2"
+VERSION = "1.1.5"
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()

--- a/src/gui/dialogs.py
+++ b/src/gui/dialogs.py
@@ -273,21 +273,6 @@ class ExportOptionsDialog:
         ttk.Checkbutton(naming_frame, text="Include author in filename", 
                        variable=self.include_author_var).pack(anchor=tk.W, pady=2)
         
-        # Folder structure
-        folder_frame = ttk.LabelFrame(frame, text="Folder Structure", padding="10")
-        folder_frame.pack(fill=tk.X, pady=(0, 10))
-        
-        self.create_subfolder_var = tk.BooleanVar()
-        ttk.Checkbutton(folder_frame, text="Create subfolder for export", 
-                       variable=self.create_subfolder_var).pack(anchor=tk.W, pady=2)
-        
-        ttk.Label(folder_frame, text="Subfolder name pattern:").pack(anchor=tk.W, pady=(5, 2))
-        self.subfolder_pattern_var = tk.StringVar()
-        ttk.Entry(folder_frame, textvariable=self.subfolder_pattern_var, 
-                 width=40).pack(anchor=tk.W)
-        ttk.Label(folder_frame, text="Use {date} for current date", 
-                 font=('TkDefaultFont', 8)).pack(anchor=tk.W)
-        
         # Duplicate handling
         dup_frame = ttk.LabelFrame(frame, text="Duplicate Files", padding="10")
         dup_frame.pack(fill=tk.X)
@@ -481,8 +466,6 @@ class ExportOptionsDialog:
         
         self.include_ccli_var.set(self.config.get('export.include_ccli_in_filename', False))
         self.include_author_var.set(self.config.get('export.include_author_in_filename', False))
-        self.create_subfolder_var.set(self.config.get('export.create_subfolder', False))
-        self.subfolder_pattern_var.set(self.config.get('export.subfolder_name', 'ProPresenter_Export_{date}'))
         self.overwrite_var.set(self.config.get('export.overwrite_existing', False))
         
         # Formatting
@@ -514,8 +497,6 @@ class ExportOptionsDialog:
         
         self.config.set('export.include_ccli_in_filename', self.include_ccli_var.get(), save=False)
         self.config.set('export.include_author_in_filename', self.include_author_var.get(), save=False)
-        self.config.set('export.create_subfolder', self.create_subfolder_var.get(), save=False)
-        self.config.set('export.subfolder_name', self.subfolder_pattern_var.get(), save=False)
         self.config.set('export.overwrite_existing', self.overwrite_var.get(), save=False)
         
         # Formatting

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -73,8 +73,6 @@ class ConfigManager:
             },
             "export": {
                 "output_directory": None,  # User's selected output directory
-                "create_subfolder": False,
-                "subfolder_name": "ProPresenter_Export_{date}",
                 "include_ccli_in_filename": False,
                 "include_author_in_filename": False,
                 "overwrite_existing": False,


### PR DESCRIPTION
## Summary
- Removes the broken subfolder export feature from Export Options dialog
- Closes #13

## Changes
- Removed subfolder creation UI elements from Export Options dialog (File Naming tab)
- Removed `create_subfolder` and `subfolder_name` settings from configuration
- Simplified the export dialog by removing non-functional UI elements
- Updated version to 1.1.5
- Updated CHANGELOG with fix details

## Problem
The subfolder export option was displayed in the UI under "Export Options > Folder Structure" but was never implemented in the actual export logic. This caused confusion as users could configure the option but it had no effect.

## Solution
Since this feature is not needed and adds unnecessary complexity, it has been removed entirely from the application.

## Test Plan
- [x] Application starts without errors
- [x] Export Options dialog opens correctly
- [x] Folder Structure section no longer appears in File Naming tab
- [x] Export functionality still works as expected
- [x] Settings are saved correctly without subfolder options

🤖 Generated with [Claude Code](https://claude.ai/code)