### PR TITLE
fix: Update tests and implement proper thread cancellation (#20, #22)

### DIFF
--- a/tests/test_rtf_processing.py
+++ b/tests/test_rtf_processing.py
@@ -97,19 +97,20 @@ That repeats
 verse
 This is the second verse
 More content here"""
-        
+
         result = self.detector.detect_sections(text)
-        
+
         self.assertTrue(result['has_sections'])
         self.assertEqual(len(result['sections']), 3)
-        
+
         sections = result['sections']
-        self.assertEqual(sections[0]['type'], 'verse')
-        self.assertEqual(sections[1]['type'], 'chorus')
-        self.assertEqual(sections[2]['type'], 'verse')
-        
+        # Section types are mapped to capitalized English names
+        self.assertEqual(sections[0]['type'], 'Verse')
+        self.assertEqual(sections[1]['type'], 'Chorus')
+        self.assertEqual(sections[2]['type'], 'Verse')
+
         self.assertIn('first verse', sections[0]['content'])
-        self.assertIn('chorus', sections[1]['content'])
+        self.assertIn('chorus', sections[1]['content'].lower())
         self.assertIn('second verse', sections[2]['content'])
     
     def test_numbered_sections(self):
@@ -122,16 +123,17 @@ Chorus content
 
 verse 2
 Second verse content"""
-        
+
         result = self.detector.detect_sections(text)
-        
+
         self.assertTrue(result['has_sections'])
         self.assertEqual(len(result['sections']), 3)
-        
-        # All verse sections should be normalized to 'verse'
+
+        # Numbered sections include the number in the type (e.g., 'Verse 1')
         sections = result['sections']
-        self.assertEqual(sections[0]['type'], 'verse')
-        self.assertEqual(sections[2]['type'], 'verse')
+        self.assertEqual(sections[0]['type'], 'Verse 1')
+        self.assertEqual(sections[1]['type'], 'Chorus')
+        self.assertEqual(sections[2]['type'], 'Verse 2')
     
     def test_swedish_section_mapping(self):
         """Test mapping of Swedish section names to English."""
@@ -140,15 +142,15 @@ Swedish verse content
 
 refräng
 Swedish chorus content"""
-        
+
         result = self.detector.detect_sections(text)
-        
+
         self.assertTrue(result['has_sections'])
         sections = result['sections']
-        
-        # Should be mapped to English equivalents
-        self.assertEqual(sections[0]['type'], 'verse')
-        self.assertEqual(sections[1]['type'], 'chorus')
+
+        # Swedish section names are mapped to capitalized English equivalents
+        self.assertEqual(sections[0]['type'], 'Verse')
+        self.assertEqual(sections[1]['type'], 'Chorus')
     
     def test_no_sections_fallback(self):
         """Test fallback when no sections are detected."""
@@ -297,10 +299,10 @@ class TestIntegratedWorkflow(unittest.TestCase):
         self.assertIn('flödar', full_text)
         self.assertIn('kärlek', full_text)
         
-        # Verify section structure
-        verse_sections = [s for s in sections['sections'] if s['type'] == 'verse']
-        chorus_sections = [s for s in sections['sections'] if s['type'] == 'chorus']
-        
+        # Verify section structure (types are capitalized English names)
+        verse_sections = [s for s in sections['sections'] if s['type'] == 'Verse']
+        chorus_sections = [s for s in sections['sections'] if s['type'] == 'Chorus']
+
         self.assertEqual(len(verse_sections), 2)
         self.assertEqual(len(chorus_sections), 1)
 


### PR DESCRIPTION
## Summary
This PR fixes two issues discovered during the code health check:

### Issue #20: Unit tests fail due to section type case mismatch
- Updated test expectations to match actual section detector behavior
- Section types are properly mapped to capitalized English names (e.g., `'Verse'`, `'Chorus'`)
- Numbered sections include the number (e.g., `'Verse 1'`, `'Verse 2'`)

### Issue #22: Thread cancellation doesn't actually stop export thread
- Added `threading.Event` for signaling cancellation to the export thread
- Export loop now checks the cancel event before processing each song
- Cancel button actually stops the export thread gracefully
- Shows appropriate message when export is cancelled, including count of songs exported before cancellation

## Changes
- `tests/test_rtf_processing.py`: Updated 4 test methods to expect capitalized section types
- `src/gui/main_window.py`: Added `export_cancel_event`, updated `start_export`, `cancel_export`, and `export_complete` methods
- `src/export/propresenter.py`: Added `cancel_event` parameter to `export_songs_batch` and cancellation check in export loop

## Test plan
- [x] All 14 unit tests pass
- [x] Syntax check passes on all modified files
- [ ] Manual test: Start export, click Cancel, verify export stops and shows cancellation message
- [ ] Manual test: Complete export normally, verify it still works

Closes #20
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)