### PR TITLE
chore: Release v1.2.7

### DIFF
--- a/build_scripts/version_info.py
+++ b/build_scripts/version_info.py
@@ -9,8 +9,8 @@
 
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(1, 2, 6, 0),
-    prodvers=(1, 2, 6, 0),
+    filevers=(1, 2, 7, 0),
+    prodvers=(1, 2, 7, 0),
     mask=0x3f,
     flags=0x0,
     OS=0x40004,
@@ -25,12 +25,12 @@ VSVersionInfo(
         u'040904B0',
         [StringStruct(u'CompanyName', u'EWExport Open Source Project'),
         StringStruct(u'FileDescription', u'EasyWorship to ProPresenter Converter - A tool for converting worship song databases'),
-        StringStruct(u'FileVersion', u'1.2.6.0'),
+        StringStruct(u'FileVersion', u'1.2.7.0'),
         StringStruct(u'InternalName', u'ewexport'),
         StringStruct(u'LegalCopyright', u'Copyright (c) 2025 - MIT License'),
         StringStruct(u'OriginalFilename', u'ewexport.exe'),
         StringStruct(u'ProductName', u'EasyWorship to ProPresenter Converter'),
-        StringStruct(u'ProductVersion', u'1.2.6.0'),
+        StringStruct(u'ProductVersion', u'1.2.7.0'),
         StringStruct(u'Comments', u'Open source worship song converter tool. Source available at github.com/karllinder/ewexport'),
         StringStruct(u'LegalTrademarks', u''),
         StringStruct(u'PrivateBuild', u''),

--- a/src/version.py
+++ b/src/version.py
@@ -6,7 +6,7 @@ All other modules should import from here rather than defining their own version
 """
 
 # Application version - update this single location for new releases
-__version__ = "1.2.6"
+__version__ = "1.2.7"
 
 # Schema versions for configuration files
 SETTINGS_SCHEMA_VERSION = "1.2.0"


### PR DESCRIPTION
## Release v1.2.7

Bump version to 1.2.7 for release.

### Changes in this release:
- **#28**: Fixed string version comparison that fails for versions >= 1.10.x
- **#29**: Fixed incomplete version migration (only handled v1.0.0)
- **#30**: Fixed hardcoded Windows paths breaking Mac/Linux compatibility
- **#31**: Fixed hardcoded version in main.py not using centralized version
- **#33**: Fixed skip file message showing "successfully exported" instead of "skipped"

🤖 Generated with [Claude Code](https://claude.com/claude-code)