### PR TITLE
fix: Harden update URL handling and custom-rename path construction

### DIFF
--- a/src/export/propresenter.py
+++ b/src/export/propresenter.py
@@ -663,6 +663,9 @@ class ProPresenter6Exporter:
                         else:
                             # Custom rename
                             custom_name = action.split(':', 1)[1] if ':' in action else action
+                            # Sanitize so a name like "..\evil" cannot escape the
+                            # chosen export directory or introduce path separators.
+                            custom_name = self.sanitize_filename(custom_name)
                             file_path = file_path.parent / f"{custom_name}.pro6"
                 
                 # Export song with potentially modified path

--- a/src/utils/update_checker.py
+++ b/src/utils/update_checker.py
@@ -146,10 +146,17 @@ class UpdateChecker:
     
     def open_specific_release(self, release_url: str):
         """Open a specific release page in the default browser
-        
+
         Args:
             release_url: URL to the specific release
         """
+        # Only allow https:// URLs. The release URL comes from the GitHub API
+        # response, so a compromised release could otherwise supply javascript:,
+        # file://, or an OS-registered scheme handler.
+        if not isinstance(release_url, str) or not release_url.startswith('https://'):
+            logger.warning(f"Refusing to open non-https release URL: {release_url!r}")
+            webbrowser.open(self.GITHUB_RELEASES_URL)
+            return
         webbrowser.open(release_url)
     
     def should_check_on_startup(self) -> bool:


### PR DESCRIPTION
## Summary
- `update_checker.open_specific_release` now only opens `https://` URLs and falls back to the hardcoded releases page otherwise, so a compromised GitHub release cannot hand `webbrowser.open` a `javascript:`/`file:`/custom-scheme URL.
- ProPresenter duplicate-handler now passes the user-supplied custom rename through `sanitize_filename`, matching every other title-derived path and preventing a typed `..\name` from escaping the chosen export directory.

Both findings are low severity (both require a prior compromise or a user actively attacking their own machine), but the code is now consistent with how every other URL/path is already handled.

## Test plan
- [ ] Launch the built `dist/ewexport.exe` and confirm the app still starts and loads a database.
- [ ] Trigger the "Check for updates" flow against the real GitHub release and confirm the release page opens.
- [ ] Export a set of songs where titles collide, choose "Rename (custom)" in the duplicate dialog, and confirm the resulting file lands inside the chosen export directory (including when the typed name contains `..` or path separators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)