### PR TITLE
chore: Bump version to 1.3.2

### DIFF
--- a/src/version.py
+++ b/src/version.py
@@ -6,14 +6,14 @@ All other modules should import from here rather than defining their own version
 """
 
 # Application version - update this single location for new releases
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 # Schema versions for configuration files
 SETTINGS_SCHEMA_VERSION = "1.2.0"
 SECTION_MAPPINGS_SCHEMA_VERSION = "1.2.0"
 
 # Release information
-RELEASE_DATE = "February 2026"
+RELEASE_DATE = "April 2026"
 RELEASE_YEAR = "2026"
 
 def get_version() -> str:


### PR DESCRIPTION
## Summary
- Bumps `src/version.py` to `1.3.2` and updates `RELEASE_DATE` to April 2026 for the security-fix release.

Companion to #48 (already merged), which contains the actual code changes.

## Test plan
- [ ] `src/version.py` shows `1.3.2` on merge.
- [ ] Built `dist/ewexport.exe` reports 1.3.2 in its version metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)