### PR TITLE
chore: Update repo references karllinder -> coldreckon

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A Windows desktop application that converts songs from EasyWorship 6.1 database 
 
 ### Download Executable (Recommended)
 
-1. Go to the [Latest Release](https://github.com/karllinder/ewexport/releases/latest)
+1. Go to the [Latest Release](https://github.com/coldreckon/ewexport/releases/latest)
 2. Download `ewexport.exe`
 3. Run it from anywhere - it's completely standalone
 
@@ -35,7 +35,7 @@ A Windows desktop application that converts songs from EasyWorship 6.1 database 
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/karllinder/ewexport.git
+   git clone https://github.com/coldreckon/ewexport.git
    cd ewexport
    ```
 

--- a/build_scripts/build_and_release.py
+++ b/build_scripts/build_and_release.py
@@ -66,7 +66,7 @@ def get_repo_slug():
             return slug
     except (subprocess.CalledProcessError, FileNotFoundError):
         pass
-    return 'karllinder/ewexport'
+    return 'coldreckon/ewexport'
 
 def calculate_sha256(file_path):
     """Calculate SHA256 hash of file"""

--- a/build_scripts/build_and_release_safe.py
+++ b/build_scripts/build_and_release_safe.py
@@ -56,7 +56,7 @@ def get_repo_slug():
             return slug
     except (subprocess.CalledProcessError, FileNotFoundError):
         pass
-    return 'karllinder/ewexport'
+    return 'coldreckon/ewexport'
 
 def calculate_sha256(file_path):
     """Calculate SHA256 hash of file"""

--- a/build_scripts/build_clean.py
+++ b/build_scripts/build_clean.py
@@ -48,7 +48,7 @@ VSVersionInfo(
         StringStruct(u'OriginalFilename', u'ewexport.exe'),
         StringStruct(u'ProductName', u'EasyWorship to ProPresenter Converter'),
         StringStruct(u'ProductVersion', u'{win_version}'),
-        StringStruct(u'Comments', u'Open source worship song converter tool. Source available at github.com/karllinder/ewexport'),
+        StringStruct(u'Comments', u'Open source worship song converter tool. Source available at github.com/coldreckon/ewexport'),
         StringStruct(u'LegalTrademarks', u''),
         StringStruct(u'PrivateBuild', u''),
         StringStruct(u'SpecialBuild', u'')])

--- a/build_scripts/upload_release.py
+++ b/build_scripts/upload_release.py
@@ -73,7 +73,7 @@ def upload_to_release(version, exe_path):
         ], check=True)
         
         print(f"✅ Successfully uploaded to release v{version}")
-        print(f"🌐 View at: https://github.com/karllinder/ewexport/releases/tag/v{version}")
+        print(f"🌐 View at: https://github.com/coldreckon/ewexport/releases/tag/v{version}")
         
         # Update release description with hash
         release_body = f"""SHA256: `{sha256}`

--- a/build_scripts/upload_release_safe.py
+++ b/build_scripts/upload_release_safe.py
@@ -78,7 +78,7 @@ def upload_to_release(version, exe_path):
         ], check=True)
         
         print(f"[OK] Successfully uploaded to release v{version}")
-        print(f"[INFO] View at: https://github.com/karllinder/ewexport/releases/tag/v{version}")
+        print(f"[INFO] View at: https://github.com/coldreckon/ewexport/releases/tag/v{version}")
         
         # Update release description with hash
         release_body = f"""SHA256: `{sha256}`

--- a/build_scripts/version_info.py
+++ b/build_scripts/version_info.py
@@ -29,7 +29,7 @@ VSVersionInfo(
         StringStruct(u'OriginalFilename', u'ewexport.exe'),
         StringStruct(u'ProductName', u'EasyWorship to ProPresenter Converter'),
         StringStruct(u'ProductVersion', u'1.4.0.0'),
-        StringStruct(u'Comments', u'Open source worship song converter tool. Source available at github.com/karllinder/ewexport'),
+        StringStruct(u'Comments', u'Open source worship song converter tool. Source available at github.com/coldreckon/ewexport'),
         StringStruct(u'LegalTrademarks', u''),
         StringStruct(u'PrivateBuild', u''),
         StringStruct(u'SpecialBuild', u'')])

--- a/build_scripts/version_info_template.py
+++ b/build_scripts/version_info_template.py
@@ -30,7 +30,7 @@ VSVersionInfo(
         StringStruct(u'OriginalFilename', u'ewexport.exe'),
         StringStruct(u'ProductName', u'EasyWorship to ProPresenter Converter'),
         StringStruct(u'ProductVersion', u'{version}.0'),
-        StringStruct(u'Comments', u'Open source worship song converter tool. Source available at github.com/karllinder/ewexport'),
+        StringStruct(u'Comments', u'Open source worship song converter tool. Source available at github.com/coldreckon/ewexport'),
         StringStruct(u'LegalTrademarks', u''),
         StringStruct(u'PrivateBuild', u''),
         StringStruct(u'SpecialBuild', u'')])

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     description="Convert songs from EasyWorship 6.1 to ProPresenter 6 format",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/karllinder/ewexport",
+    url="https://github.com/coldreckon/ewexport",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     license="MIT",

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -320,7 +320,7 @@ Features:
 • Full Swedish character support
 
 © {RELEASE_YEAR} - Created with Python and CustomTkinter
-GitHub: https://github.com/karllinder/ewexport"""
+GitHub: https://github.com/coldreckon/ewexport"""
         
         messagebox.showinfo("About", about_text)
     

--- a/src/utils/update_checker.py
+++ b/src/utils/update_checker.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 class UpdateChecker:
     """Handles checking for application updates from GitHub"""
 
-    GITHUB_API_URL = "https://api.github.com/repos/karllinder/ewexport/releases/latest"
-    GITHUB_RELEASES_URL = "https://github.com/karllinder/ewexport/releases"
+    GITHUB_API_URL = "https://api.github.com/repos/coldreckon/ewexport/releases/latest"
+    GITHUB_RELEASES_URL = "https://github.com/coldreckon/ewexport/releases"
     CURRENT_VERSION = __version__  # Imported from centralized version module
     
     def __init__(self, config=None):


### PR DESCRIPTION
Sweeps all `karllinder/ewexport` references to `coldreckon/ewexport`.

Notable: **`src/utils/update_checker.py`** — the in-app auto-update checker now points its API and releases URLs at `coldreckon/ewexport`, so installed apps check the correct repo for updates. Also updates `setup.py` URL, README links, the About dialog, release-script fallback slugs, and the version-resource generator (`build_clean.py`) + its generated `version_info.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)