### PR TITLE
release: Stable 1.4.0 (signed GA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Digitally signed Windows releases via **Azure Artifact Signing** (organization / Public
-  Trust). Signed builds show a verified publisher and no longer trigger the SmartScreen
-  "unknown publisher" warning. *(Azure identity validation in progress.)*
-- Application icon embedded in `ewexport.exe`.
-- CI pipeline (`.github/workflows/build-release.yml`) that builds, signs, verifies, and
-  publishes the executable to the GitHub Release on a version tag.
+## [1.4.0] - 2026-07-29
 
-### Changed
-- Releases are now built and signed by CI instead of being built locally and uploaded
-  manually. The local build scripts remain for development and produce unsigned binaries.
-
-## [1.4.0] - 2026-06-10
+First stable release of the CustomTkinter GUI, now shipped as a **digitally signed**
+Windows executable. (Previewed as `1.4.0-beta.1` on 2026-06-10.)
 
 ### Added
 - Reworked the entire GUI on **CustomTkinter** for a modern look: main window, settings
   window, and export dialogs, plus a theme module for appearance and `ttk` styling.
+- Digitally signed Windows releases via **Azure Artifact Signing** (organization / Public
+  Trust). Signed builds show the verified publisher "Saronförsamlingen i Göteborg" and no
+  longer trigger the SmartScreen "unknown publisher" warning.
+- Application icon embedded in `ewexport.exe`.
+- CI pipeline (`.github/workflows/build-release.yml`) that builds, signs, verifies, and
+  publishes the executable to the GitHub Release on a version tag.
 - Beta / pre-release track support in the local release scripts (`v*-beta.N` tags marked as
   pre-releases).
 - Baseline GUI unit tests.
@@ -34,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decode `gh` CLI output as UTF-8 in the release scripts.
 
 ### Changed
+- Releases are now built and signed by CI instead of being built locally and uploaded
+  manually. The local build scripts remain for development and produce unsigned binaries.
 - Bundle CustomTkinter + Pillow assets in the build; regenerate the Windows version resource
   from `src/version.py` (single source of truth).
 
@@ -103,8 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial public release.
 
-[Unreleased]: https://github.com/coldreckon/ewexport/compare/v1.4.0-beta.1...HEAD
-[1.4.0]: https://github.com/coldreckon/ewexport/releases/tag/v1.4.0-beta.1
+[Unreleased]: https://github.com/coldreckon/ewexport/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/coldreckon/ewexport/releases/tag/v1.4.0
 [1.3.1]: https://github.com/coldreckon/ewexport/releases/tag/v1.3.1
 [1.3.0]: https://github.com/coldreckon/ewexport/releases/tag/v1.3.0
 [1.2.9]: https://github.com/coldreckon/ewexport/releases/tag/v1.2.9

--- a/src/version.py
+++ b/src/version.py
@@ -13,14 +13,14 @@ __version__ = "1.4.0"
 # Pre-release suffix for beta/rc builds. Empty string ("") for stable releases.
 # Examples: "beta.1" -> full version "1.4.0-beta.1" (GitHub release tag
 # "v1.4.0-beta.1", marked as a pre-release). Bump for each beta (beta.2, rc.1...).
-PRERELEASE = "beta.1"
+PRERELEASE = ""
 
 # Schema versions for configuration files
 SETTINGS_SCHEMA_VERSION = "1.2.0"
 SECTION_MAPPINGS_SCHEMA_VERSION = "1.2.0"
 
 # Release information
-RELEASE_DATE = "June 2026"
+RELEASE_DATE = "2026-07-29"
 RELEASE_YEAR = "2026"
 
 def get_version() -> str:


### PR DESCRIPTION
Promotes **1.4.0** from beta to a stable, code-signed release.

- `src/version.py`: `PRERELEASE=""`, `RELEASE_DATE=2026-07-29`. The About dialog now shows **Version: 1.4.0 / Released: 2026-07-29**; the embedded Windows resource and `ewexport.exe --version` report `1.4.0`.
- `CHANGELOG.md`: consolidated `## [1.4.0] - 2026-07-29` entry (GUI + signing), links fixed.

Verified locally: `pytest tests/test_version.py` (13 passed), clean PyInstaller build reports `ewexport 1.4.0`, file properties `1.4.0.0`.

After merge, tag **`v1.4.0`** to trigger the signed release pipeline (build → sign → verify → publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)